### PR TITLE
Remove receive queue

### DIFF
--- a/samples/Chat/src/Sylver.Chat.Server/ChatServer.cs
+++ b/samples/Chat/src/Sylver.Chat.Server/ChatServer.cs
@@ -26,17 +26,6 @@ namespace Sylver.Chat.Server
         protected override void OnClientConnected(ChatServerClient client)
         {
             Console.WriteLine($"New client '{client.Id}' connected from {client.Socket.RemoteEndPoint.ToString()}");
-
-            for (int i = 0; i < 1000; i++)
-            {
-                using (var packet = new NetPacket())
-                {
-                    packet.Write<byte>((byte)ChatPacketType.Test);
-                    packet.Write<int>(i);
-                    SendTo(client, packet);
-                }
-                Console.WriteLine("Sent test packet: " + i);
-            }
         }
 
         /// <inheritdoc />

--- a/src/Sylver.Network/Client/NetClient.cs
+++ b/src/Sylver.Network/Client/NetClient.cs
@@ -7,6 +7,9 @@ using System.Net.Sockets;
 
 namespace Sylver.Network.Client
 {
+    /// <summary>
+    /// Provides a mechanism to connect to a remote TCP server.
+    /// </summary>
     public class NetClient : NetConnection, INetClient
     {
         private IPacketProcessor _packetProcessor;
@@ -71,7 +74,7 @@ namespace Sylver.Network.Client
 
             if (ClientConfiguration == null)
             {
-                throw new ArgumentNullException("Client configuration is not set.", nameof(ClientConfiguration));
+                throw new ArgumentNullException(nameof(ClientConfiguration), "Client configuration is not set.");
             }
 
             if (ClientConfiguration.Port <= 0)
@@ -130,14 +133,20 @@ namespace Sylver.Network.Client
             base.Dispose(disposing);
         }
 
+        /// <summary>
+        /// Method called when the client is connected to the remote server.
+        /// </summary>
         protected virtual void OnConnected() { }
 
+        /// <summary>
+        /// Method called when the client is disconnected from the remote server.
+        /// </summary>
         protected virtual void OnDisconnected() { }
 
         private void OnClientConnected(object sender, EventArgs e)
         {
-            _receiver.Start(this);
             OnConnected();
+            _receiver.Start(this);
         }
 
         private void OnClientConnectionError(object sender, SocketError e)


### PR DESCRIPTION
Covers issue #5

This PR removes the recevive queue in the `NetReceiver` and process the packet imediatly once it arrives before reading more packets.
